### PR TITLE
[PR] Deregister Yoast scripts on factsheet admin

### DIFF
--- a/includes/class-wsuwp-graduate-degree-programs.php
+++ b/includes/class-wsuwp-graduate-degree-programs.php
@@ -235,6 +235,10 @@ class WSUWP_Graduate_Degree_Programs {
 	 */
 	public function admin_enqueue_scripts( $hook_suffix ) {
 		if ( in_array( $hook_suffix, array( 'post.php', 'post-new.php' ), true ) && 'gs-factsheet' === get_current_screen()->id ) {
+			wp_deregister_script( 'yoast-seo-post-scraper' );
+			wp_deregister_script( 'yoast-seo-term-scraper' );
+			wp_deregister_script( 'yoast-seo-featured-image' );
+
 			wp_enqueue_style( 'gsdp-admin', get_stylesheet_directory_uri() . '/css/factsheet-admin.css', array(), WSUWP_Graduate_School_Theme()->theme_version() );
 			wp_register_script( 'gsdp-factsheet-admin', get_stylesheet_directory_uri() . '/js/factsheet-admin.min.js', array( 'jquery', 'underscore', 'jquery-ui-autocomplete' ), WSUWP_Graduate_School_Theme()->theme_version(), true );
 


### PR DESCRIPTION
JS errors because of the missing meta box were causing the remaining JS on the page to crash. See https://github.com/Yoast/wordpress-seo/issues/4367